### PR TITLE
Handle void response from RPC service method

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -63,17 +63,22 @@ class BaseClient {
       });
 
       if (res.ok) {
-        const body = await res.body();
-        
+        // NB: Checking for null here first might be enough
+        // readable stream is null for a response with no body
+        if (res.body === null) return null;
+
+        // body stream to text
+        const text = await res.text();
+
         // should never be null, don't necessarily need this line
-        if (body === null) return null;
+        if (text === null) return null;
 
         // could be undefined (but most likely empty string), not json parse-able
         // interpret empty body as the void response
-        if (!body || body === "") return;
+        if (!text) return;
 
         // should be parse-able now if valid (returning null, string, array or object)
-        return JSON.parse(body);
+        return JSON.parse(text);
       }
 
       status = res.status;

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -63,7 +63,17 @@ class BaseClient {
       });
 
       if (res.ok) {
-        return await res.json();
+        const body = await res.body();
+        
+        // should never be null, don't necessarily need this line
+        if (body === null) return null;
+
+        // could be undefined (but most likely empty string), not json parse-able
+        // interpret empty body as the void response
+        if (!body || body === "") return;
+
+        // should be parse-able now if valid (returning null, string, array or object)
+        return JSON.parse(body);
       }
 
       status = res.status;


### PR DESCRIPTION
If an RPC method is returning "void" then the response is not JSON.

I know Mike tried to approach this with you, I just wanted to put up a possible fix for discussion.

Totally understand if you want to approach this differently. Or you want me to keep changing methods to return null in stead of void.