### PR TITLE
Fix: error.toString shows [object Object]

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -121,8 +121,9 @@ class RpcResponseError {
       writable: true,
     });
 
+    // .message .code .type .expose .instance .type are applied here
     Object.assign(this, responseBody);
-    if (!this.source) this.source = [];
+
     this.source = [source, ...(this.source || [])];
 
     Object.defineProperty(this, "stack", {
@@ -137,6 +138,12 @@ class RpcResponseError {
           .join("\n"),
       writable: true,
     });
+  }
+
+  toString() {
+    // defineProperty not recognized by typescript, nor is the result of assign recognizable
+    const { name, message, instance } = this as any;
+    return `${name}: ${message} [${instance}]`;
   }
 }
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -122,20 +122,22 @@ const EXCLUDED_META_KEYS = [
 
 function logfmt(data: Record<string, any>) {
   // taken from https://github.com/csquared/node-logfmt/blob/master/lib/stringify.js
-  var line = "";
+  // cleaned up a little
+  let line = "";
 
-  for (var key in data) {
+  for (const key in data) {
     if (EXCLUDED_META_KEYS.includes(key)) continue;
 
-    var value = data[key];
-    var is_null = false;
-    if (value == null) {
-      is_null = true;
+    let value = data[key];
+    const is_null = value == null;
+    if (is_null) {
       value = "";
-    } else value = value.toString();
+    } else {
+      value = value.toString();
+    }
 
-    var needs_quoting = value.indexOf(" ") > -1 || value.indexOf("=") > -1;
-    var needs_escaping = value.indexOf('"') > -1 || value.indexOf("\\") > -1;
+    const needs_quoting = value.indexOf(" ") > -1 || value.indexOf("=") > -1;
+    const needs_escaping = value.indexOf('"') > -1 || value.indexOf("\\") > -1;
 
     if (needs_escaping) value = value.replace(/["\\]/g, "\\$&");
     if (needs_quoting || needs_escaping) value = '"' + value + '"';

--- a/test/rpc-response-error.test.ts
+++ b/test/rpc-response-error.test.ts
@@ -1,0 +1,36 @@
+import test from "ava";
+
+import { RpcResponseError } from "../lib/client";
+
+test("RpcResponseError", (t) => {
+  const err: any = new RpcResponseError("my_source", {
+    type: "FooError",
+    code: 123,
+    expose: true,
+    message: "foo",
+    namespace: "foo",
+    instance: "bar",
+    source: ["foo", "bar"],
+    upstreamCode: 456,
+    upstreamMessage: "a bad thing happened",
+  });
+
+  t.is(
+    err.toString(),
+    'RpcResponseError: foo [bar] upstreamCode=456 upstreamMessage="a bad thing happened"'
+  );
+  t.is(err.name, "RpcResponseError");
+  t.is(err.type, "FooError");
+  t.is(err.code, 123);
+  t.is(err.expose, true);
+  t.is(err.message, "foo");
+  t.is(err.namespace, "foo");
+  t.is(err.instance, "bar");
+  t.deepEqual(err.source, ["my_source", "foo", "bar"]);
+  t.is(
+    err.stack,
+    'RpcResponseError: foo [bar] upstreamCode=456 upstreamMessage="a bad thing happened"\n    via bar\n    via foo\n    via my_source'
+  );
+  t.is(err.upstreamCode, 456);
+  t.is(err.upstreamMessage, "a bad thing happened");
+});


### PR DESCRIPTION
Any attempt to convert to string results in `[object Object]` rather than the standard `ErrorType: error message`, or the previous LOKE format `ErrorType: error message [instance]` or the LOKE error logfmt-ish type `ErrorType: error message [instance] key1=value1 key2=value2`

Also affects error.stack

I'm assuming not extending Error is deliberate here as we don't want a native stack trace in this case