### PR TITLE
Update peer dependency for prom-client to allow versions >=12

### DIFF
--- a/.github/workflows/npm-publlish.yml
+++ b/.github/workflows/npm-publlish.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@loke/http-rpc-client",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/http-rpc-client",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "ISC",
       "dependencies": {
-        "@loke/context": "^0.0.1"
+        "@loke/context": "^0.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
@@ -671,9 +671,10 @@
       "license": "MIT"
     },
     "node_modules/@loke/context": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@loke/context/-/context-0.0.1.tgz",
-      "integrity": "sha512-FZkpZ/OMJxQzwpPOlpZezx2QwehUZCObqgqR5GcnQX+J/rmncvUhf5FzBx4PafdvZ6zcdtr9F7xmGdFZaryWvg=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@loke/context/-/context-0.1.0.tgz",
+      "integrity": "sha512-4Ka1z4rSkxChkSZBteH24awWCb0/Rth9zUOHyLtVQOHYT6Xk9Dfk3+17eSGC5ACFBZ/lElCDOhKNy8lCy9Xr1Q==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loke/http-rpc-client",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loke/http-rpc-client",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "ISC",
       "dependencies": {
         "@loke/context": "^0.1.0"
@@ -28,7 +28,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "prom-client": ">=12"
+        "prom-client": ">=12 <=15"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "prom-client": ">=12 <=14"
+        "prom-client": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript-eslint": "^8.21.0"
   },
   "dependencies": {
-    "@loke/context": "^0.0.1"
+    "@loke/context": "^0.1.0"
   },
   "peerDependencies": {
     "prom-client": ">=12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc-client",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "@loke/context": "^0.1.0"
   },
   "peerDependencies": {
-    "prom-client": ">=12"
+    "prom-client": ">=12 <=15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "@loke/context": "^0.0.1"
   },
   "peerDependencies": {
-    "prom-client": ">=12 <=14"
+    "prom-client": ">=12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loke/http-rpc-client",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

  - Remove upper bound restriction on prom-client peer dependency to support version 15 and beyond
  - Update package version to 5.1.1
  - Updated CI so then it doesn't publish on PR pushes
  - Updated `@loke/context` package to 0.1.0 to support newer projects