### PR TITLE
OIDC updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,13 +34,14 @@ jobs:
     needs: ["test", "lint"]
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write # required for npm OIDC trusted publishing
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
+      - run: npm publish --access public


### PR DESCRIPTION
Internal change only

stop using npm token so it uses OIDC

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

##  I have:
- [ ] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_
